### PR TITLE
Update composer.json to support php7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "~5.5.0|~5.6.0|~7.0.0",
+        "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0",
         "magento/framework": "*",
         "magento/module-store": "*",
         "magento/module-checkout": "*",


### PR DESCRIPTION
Please update php required version to support Magento 2.2.x. Currently, we are crashed once we try to run composer install.
Please consider this.

Thanks so much