### PR TITLE
Enable store selection on map using markers

### DIFF
--- a/view/frontend/web/js/view/checkout/shipping/store-map.js
+++ b/view/frontend/web/js/view/checkout/shipping/store-map.js
@@ -92,6 +92,39 @@ define([
             var address = new storeDeliveryAddress(this.currentRetailerId(), retailerData);
 
             quote.shippingAddress(address);
+        },
+
+        loadMarkers: function () {
+            var markers = [],
+                isMarkerCluster = this.marker_cluster === '1';
+            var icon = L.icon({iconUrl: this.markerIcon, iconSize: this.markerIconSize});
+            this.markers().forEach(function (markerData) {
+                var customIcon = icon;
+                if ('customIcon' in markerData && markerData.customIcon !== null &&
+                    markerData.customIcon !== undefined && markerData.customIcon !== ""
+                ) {
+                    customIcon = L.icon({iconUrl: markerData.customIcon, iconSize: this.markerIconSize});
+                }
+
+                var currentMarker = [markerData.latitude, markerData.longitude];
+                var marker = L.marker(currentMarker, {icon: customIcon});
+                if (!isMarkerCluster) {
+                    marker.addTo(this.map);
+                }
+                marker.on('click', function () {
+                    this.currentRetailerId(markerData.id);
+                    this.setShippingAddress();
+                }.bind(this));
+                markers.push(marker);
+            }.bind(this));
+
+            var group = new L.featureGroup(markers);
+            if (isMarkerCluster) {
+                group = new L.markerClusterGroup();
+                group.addLayers(markers);
+                this.map.addLayer(group);
+            }
+            this.initialBounds = group.getBounds();
         }
     });
 });


### PR DESCRIPTION
This pull request is our 'simple' answer to an identified UX default.
Referencing this issue : (https://github.com/Smile-SA/magento2-module-store-delivery/issues/15)

When choosing a store in shipping step, we can't select it using markers on map. It appears to be quite confusing for users, because details are displayed but retailerId not set as current shop.

A solution could be to set `this.currentRetailerId(markerData.id);` on click on marker.
`Smile_StoreDelivery/js/view/checkout/shipping/store-map` extends `Smile_StoreLocator/js/retailer/store-map` which extends `Smile_Map/js/map` which defines loadMarkers() method.
Considering `smile-map` is replaced in our custom module's `requirejs-config` in order to develop extra functionnalities about markers and stock, we were forced to redeclare loadMarkers() here...

It would be nice to hear your thoughts on this.