### PR TITLE
Remove cancel  & disable save buttons until a store is selected

### DIFF
--- a/view/frontend/web/js/view/checkout/shipping/store-map.js
+++ b/view/frontend/web/js/view/checkout/shipping/store-map.js
@@ -1,4 +1,5 @@
 define([
+    'jquery',
     'ko',
     'smile-storelocator-map',
     'Magento_Checkout/js/model/quote',
@@ -7,7 +8,7 @@ define([
     'Smile_StoreDelivery/js/model/store-address',
     'smile-map-markers',
     'smile-storelocator-store-collection'
-], function(ko, StoreLocatorMap, quote, addressList, shipping, storeDeliveryAddress){
+], function($, ko, StoreLocatorMap, quote, addressList, shipping, storeDeliveryAddress){
 
     return StoreLocatorMap.extend({
 
@@ -88,6 +89,8 @@ define([
                     this.selectMarker(marker);
                 }
             }.bind(this));
+            // Enable store selection button
+            $('button.action-save-address').removeClass('disabled');
 
             var address = new storeDeliveryAddress(this.currentRetailerId(), retailerData);
 

--- a/view/frontend/web/js/view/shipping-address/address-renderer/store-delivery.js
+++ b/view/frontend/web/js/view/shipping-address/address-renderer/store-delivery.js
@@ -96,16 +96,9 @@ define([
                 this.popUpForm.options.buttons = [
                     {
                         text: buttons.save.text ? buttons.save.text : $t('Save Address'),
-                        class: buttons.save.class ? buttons.save.class : 'action primary action-save-address',
+                        class: buttons.save.class ? buttons.save.class + ' disabled' : 'action primary action-save-address',
                         click: function () {
                             self.updateAddress();
-                            this.closeModal();
-                        }
-                    },
-                    {
-                        text: buttons.cancel.text ? buttons.cancel.text : $t('Cancel'),
-                        class: buttons.cancel.class ? buttons.cancel.class : 'action secondary action-hide-popup',
-                        click: function () {
                             this.closeModal();
                         }
                     }


### PR DESCRIPTION
We removed cancel button from store delivery popup, as closing modal is its only purpose.

Most significantly, it seemed more coherent to disable Select Store Address button until store selection from list (address set on quote), as it may results in error : `Uncaught TypeError: this.address(...).getRetailerId is not a function` otherwise.
Moreover, when modal is closed, both store and home delivery address renderers may be binded with css: isSelected
Finally this pull request must prevent this issue from occuring : (https://github.com/Smile-SA/magento2-module-store-delivery/issues/13).

I found myself unable to create an observable attribute `disabled` on `popUpForm.options.buttons` definition, which is why i ended up with this jquery in `store-map`.

Feel free to answer if you have the solution.