### PR TITLE
Add payload-extender feature to modify shipping address payload

### DIFF
--- a/view/frontend/web/js/model/shipping-save-processor/store-delivery.js
+++ b/view/frontend/web/js/model/shipping-save-processor/store-delivery.js
@@ -23,7 +23,8 @@ define(
         'Magento_Checkout/js/model/payment-service',
         'Magento_Checkout/js/model/payment/method-converter',
         'Magento_Checkout/js/model/error-processor',
-        'Magento_Checkout/js/model/full-screen-loader'
+        'Magento_Checkout/js/model/full-screen-loader',
+        'Magento_Checkout/js/model/shipping-save-processor/payload-extender'
     ],
     function (
         ko,
@@ -33,7 +34,8 @@ define(
         paymentService,
         methodConverter,
         errorProcessor,
-        fullScreenLoader
+        fullScreenLoader,
+        payloadExtender
     ) {
         'use strict';
 
@@ -54,6 +56,8 @@ define(
                         shipping_carrier_code: quote.shippingMethod().carrier_code
                     }
                 };
+
+                payloadExtender(payload);
 
                 fullScreenLoader.startLoader();
 


### PR DESCRIPTION
In Magento v2.2.2 payload extender has been added to checkout.
This feature allows third-party extension to modify the payload for the shipping address selection process.
https://devdocs.magento.com/guides/v2.2/release-notes/ReleaseNotes2.2.2CE.html