### PR TITLE
Use notify always instead of call setShippingAddress after setting data

### DIFF
--- a/view/frontend/web/js/view/checkout/shipping/store-map.js
+++ b/view/frontend/web/js/view/checkout/shipping/store-map.js
@@ -24,7 +24,7 @@ define([
                 }
             });
 
-            this.currentRetailerId = ko.observable();
+            this.currentRetailerId = ko.observable().extend({notify: 'always'});
             this.currentRetailerId.subscribe(this.setShippingAddress.bind(this));
         },
 
@@ -116,7 +116,6 @@ define([
                 }
                 marker.on('click', function () {
                     this.currentRetailerId(markerData.id);
-                    this.setShippingAddress();
                 }.bind(this));
                 markers.push(marker);
             }.bind(this));


### PR DESCRIPTION
Call `setShippingAddress` after setting data in `currentRetailerId`, execute the `setShippingAddress` method twice.
Add `.extend({notify: 'always'})` allows run subscribe callback same if value was identical with precedent value